### PR TITLE
cmd: cm33: include asm/global_data.h for DECLARE_GLOBAL_DATA_PTR

### DIFF
--- a/cmd/cm33.c
+++ b/cmd/cm33.c
@@ -1,6 +1,7 @@
 #include <common.h>
 #include <command.h>
 #include <linux/delay.h>
+#include <asm/global_data.h>
 
 DECLARE_GLOBAL_DATA_PTR;
 


### PR DESCRIPTION
Fixes a build error due to missing macro definition for `DECLARE_GLOBAL_DATA_PTR` in cmd/cm33.c. This macro is defined in <asm/global_data.h>, which was not previously included.

Without this header, the compiler treats the macro as an undeclared identifier, resulting in a type error during build.