### PR TITLE
rz-cmn: add audio fallback for RZV2H RDK and fix dtbo names

### DIFF
--- a/include/configs/rz-cmn_env.h
+++ b/include/configs/rz-cmn_env.h
@@ -68,8 +68,7 @@
 	RZ_OVERLAY_IF_FLAG("enable_overlay_spi",          "${model_string}-${revision_major}.${revision_minor}-ext-spi.dtbo") \
 	RZ_OVERLAY_IF_FLAG("enable_overlay_can",          "${model_string}-${revision_major}.${revision_minor}-can.dtbo") \
 	RZ_OVERLAY_IF_FLAG("enable_overlay_dsi",          "${model_string}-${revision_major}.${revision_minor}-dsi.dtbo") \
-	RZ_OVERLAY_IF_FLAG("enable_overlay_audio_codec",  "${model_string}-${revision_major}.${revision_minor}-audio_codec.dtbo") \
-	RZ_OVERLAY_IF_FLAG("enable_overlay_audio_hdmi",   "${model_string}-${revision_major}.${revision_minor}-audio_hdmi.dtbo") \
+	RZ_OVERLAY_IF_FLAG("enable_overlay_audio_codec",  "${model_string}-${revision_major}.${revision_minor}-audio-codec.dtbo") \
 	RZ_OVERLAY_IF_FLAG("enable_overlay_csi_ov5640",   "${model_string}-${revision_major}.${revision_minor}-ov5640.dtbo") \
 	RZ_OVERLAY_IF_FLAG("enable_overlay_csi_ov5645",   "${model_string}-${revision_major}.${revision_minor}-cru-csi-ov5645.dtbo")
 #endif


### PR DESCRIPTION
Changes include:
    - Fix audio DTBO filenames by replacing underscores with hyphens to match the actual overlay files (audio_codec -> audio-codec).
    - Implement an audio fallback mechanism for the RZV2H RDK board. If no audio overlay is explicitly selected via environment flags, the HDMI audio overlay is applied by default.
